### PR TITLE
refactor: Change error message structure for easier parse in frontend

### DIFF
--- a/coengage/serializers.py
+++ b/coengage/serializers.py
@@ -26,14 +26,10 @@ class MyTokenObtainPairSerializer(TokenObtainPairSerializer):
     def validate(self, attrs):
         data = super().validate(attrs)
 
+        # Change the error message structure for consistency with other error handling, easier for frontend to parse
         if not self.user.is_verified:
             raise serializers.ValidationError(
-                [
-                    {
-                        "error": "Email is not verified",
-                        "message": "Email is not verified, Please verify the email to login",
-                    }
-                ]
+                {"detail": "Email is not verified, Please verify the email to login"}
             )
 
         return data
@@ -51,8 +47,9 @@ class UserSerializer(serializers.ModelSerializer):
     def validate_email(self, value):
         value = value.strip().lower()
         if not value.endswith("@northeastern.edu"):
+            # Change the error message structure for consistency with other error handling, easier for frontend to parse
             raise serializers.ValidationError(
-                "Email must be from the northeastern.edu domain"
+                {"detail": "Email must be from the northeastern.edu domain"}
             )
         return value
 


### PR DESCRIPTION
There's still another strange error message structure in built-in Django field-related error: username -> unique, as it's defined in User model, we can't change it.
That need handle error in Array.